### PR TITLE
added dnsmasq to the local configuration to redirect all *.test domains to traefik

### DIFF
--- a/configs-local/dnsmasq.conf
+++ b/configs-local/dnsmasq.conf
@@ -1,0 +1,12 @@
+#dnsmasq config, for a complete example, see:
+#  http://oss.segetech.com/intra/srv/dnsmasq.conf
+#log all dns queries
+log-queries
+#dont use hosts nameservers
+no-resolv
+#use cloudflare as default nameservers, prefer 1^4
+server=1.0.0.1
+server=1.1.1.1
+strict-order
+#explicitly define host-ip mappings
+address=/test/127.0.0.1

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -19,3 +19,14 @@ services:
     networks:
       routing:
         ipv4_address: 10.100.100.10
+  dnsmasq:
+    image: jpillora/dnsmasq:1.1.0
+    restart: always
+    container_name: reverse_proxy_dnsmasq
+    ports:
+      - 53:53/udp
+    volumes:
+      - ./configs/dnsmasq.conf:/etc/dnsmasq.conf
+    networks:
+      routing:
+        ipv4_address: 10.100.100.12

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ It uses:
  - Traefik 2.2
  - docker-compose
  - Let's encrypt
+ - DNSMasq
 
 ## Table of content
 
@@ -191,7 +192,13 @@ The dashboard shows you the configured routers, services, middlewares, etc.
 ### Add redirects for all *.test domains to traefik
 
 DNSMasq is pre-installed and configured to redirect all *.test domains to traefik. 
-To use it you have to add `127.0.0.1` as an DNS Server in your OS Settings.  
+To use DNSMasq for your *.test domains you can configure a resolver like this:
+```bash
+sudo mkdir /etc/resolver
+sudo touch /etc/resolver/test 
+echo "nameserver 0.0.0.0" | sudo tee /etc/resolver/test
+```
+Alternatively you can configure `127.0.0.1` as an DNS Server in your OS Settings. 
 
 ### Connect docker-compose service to reverse-proxy
 

--- a/readme.md
+++ b/readme.md
@@ -192,13 +192,14 @@ The dashboard shows you the configured routers, services, middlewares, etc.
 ### Add redirects for all *.test domains to traefik
 
 DNSMasq is pre-installed and configured to redirect all *.test domains to traefik. 
-To use DNSMasq for your *.test domains you can configure a resolver like this:
+To use DNSMasq for your *.test domains you can configure a resolver like this on macOS:
 ```bash
 sudo mkdir /etc/resolver
 sudo touch /etc/resolver/test 
 echo "nameserver 0.0.0.0" | sudo tee /etc/resolver/test
 ```
-Alternatively you can configure `127.0.0.1` as an DNS Server in your OS Settings. 
+On other systems you can configure `127.0.0.1` as a DNS Server in your OS Settings. 
+The default fallback DNS Server is Cloudflare `1.0.0.1` and `1.1.1.1`. Feel free to change it in `configs/dnsmasq.conf`.
 
 ### Connect docker-compose service to reverse-proxy
 

--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,11 @@ http://reverse-proxy.test
 ```
 The dashboard shows you the configured routers, services, middlewares, etc.
 
+### Add redirects for all *.test domains to traefik
+
+DNSMasq is pre-installed and configured to redirect all *.test domains to traefik. 
+To use it you have to add `127.0.0.1` as an DNS Server in your OS Settings.  
+
 ### Connect docker-compose service to reverse-proxy
 
 ```yaml


### PR DESCRIPTION
not sure about the Backfall DNS Servers. We could just add none but then someone might configure this as his only nameserver and cannot reach any other sites. 